### PR TITLE
(fix) SSEMR-602 Fix Invalid input error appears if 2 names are entered with…

### DIFF
--- a/frontend/config.json
+++ b/frontend/config.json
@@ -189,7 +189,7 @@
         "label": "Treatment supporter's name(if disclosed)",
         "validation": {
           "required": false,
-          "matches": "^[a-zA-Z\\\\s'\\\\.-]+$"
+          "matches": "^[a-zA-Z\\s'\\.-]+$"
         }
       },     
       {


### PR DESCRIPTION
… a space between them in the treatment supporters name field.